### PR TITLE
Use WrapOperation for better compatibility

### DIFF
--- a/src/main/java/com/bvengo/soundcontroller/mixin/ExtendGameOptionsScreenMixin.java
+++ b/src/main/java/com/bvengo/soundcontroller/mixin/ExtendGameOptionsScreenMixin.java
@@ -1,0 +1,21 @@
+package com.bvengo.soundcontroller.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.gui.screen.option.GameOptionsScreen;
+import net.minecraft.client.gui.widget.ThreePartsLayoutWidget;
+import net.minecraft.client.gui.widget.Widget;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(GameOptionsScreen.class)
+public class ExtendGameOptionsScreenMixin {
+    @Shadow @Final public ThreePartsLayoutWidget layout;
+
+    @WrapOperation(method = "initFooter", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ThreePartsLayoutWidget;addFooter(Lnet/minecraft/client/gui/widget/Widget;)Lnet/minecraft/client/gui/widget/Widget;", ordinal = 0))
+    protected Widget replaceDoneButton(ThreePartsLayoutWidget instance, Widget widget, Operation<Widget> original) {
+        return original.call(instance, widget);
+    }
+}

--- a/src/main/java/com/bvengo/soundcontroller/mixin/SoundOptionsScreenMixin.java
+++ b/src/main/java/com/bvengo/soundcontroller/mixin/SoundOptionsScreenMixin.java
@@ -2,38 +2,24 @@ package com.bvengo.soundcontroller.mixin;
 
 import com.bvengo.soundcontroller.Translations;
 import com.bvengo.soundcontroller.gui.AllSoundOptionsScreen;
-
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.option.GameOptionsScreen;
 import net.minecraft.client.gui.screen.option.SoundOptionsScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
 import net.minecraft.client.gui.widget.ThreePartsLayoutWidget;
+import net.minecraft.client.gui.widget.Widget;
 import net.minecraft.client.option.GameOptions;
 import net.minecraft.screen.ScreenTexts;
-
 import net.minecraft.text.Text;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(GameOptionsScreen.class)
-public class GameOptionsScreenMixin {
-    @Shadow @Final public ThreePartsLayoutWidget layout;
-
-    @Inject(method = "initFooter", at = @At("HEAD"), cancellable = true)
-    private void replaceDoneButton(CallbackInfo ci) {
-
-		//noinspection ConstantValue
-		if (!((Object)this instanceof SoundOptionsScreen)) {
-            return;
-        }
-
+@Mixin(SoundOptionsScreen.class)
+public abstract class SoundOptionsScreenMixin extends ExtendGameOptionsScreenMixin {
+    @Override
+    protected Widget replaceDoneButton(ThreePartsLayoutWidget instance, Widget widget, Operation<Widget> original) {
         ScreenAccessor screenAccessor = (ScreenAccessor) (Object) this;
         GameOptionsScreenAccessor gameOptionsScreenAccessor = (GameOptionsScreenAccessor) (Object) this;
 
@@ -48,7 +34,7 @@ public class GameOptionsScreenMixin {
         soundcontroller$addLayoutButton(client, directionalLayoutWidget, Translations.SOUND_SCREEN_TITLE, volumeOptionsScreen);
         soundcontroller$addLayoutButton(client, directionalLayoutWidget, ScreenTexts.DONE, parent);
 
-        ci.cancel();
+        return directionalLayoutWidget;
     }
 
     @Unique

--- a/src/main/resources/soundcontroller.mixins.json
+++ b/src/main/resources/soundcontroller.mixins.json
@@ -5,7 +5,8 @@
     "mixins": [],
     "client": [
         "GameOptionsScreenAccessor",
-        "GameOptionsScreenMixin",
+        "ExtendGameOptionsScreenMixin",
+        "SoundOptionsScreenMixin",
         "ScreenAccessor",
         "SoundManagerAccessor",
         "SoundSystemAccessor",


### PR DESCRIPTION
resolve #24 

Use `WrapOperation` instead of `CallbackInfo#cancel()`

----

**Changes**

* mixin registration:
  * (New) ExtendGameOptionsScreenMixin
  * GameOptionsScreenMixin -> SoundOptionsScreenMixin